### PR TITLE
142: added command to show profiler from task

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,10 @@
                 "title": "Show Profiler",
                 "when": "resourceExtname == .prof || resourceExtname == .out",
                 "icon": "$(open-preview)"
+            },
+            {
+                "command": "vsc-profiler.profilerFromTask",
+                "title": "Show Profiler"
             }
         ],
         "menus": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,6 +36,33 @@ export function activate(context: vscode.ExtensionContext) {
     });
 
     context.subscriptions.push(disposable);
+
+    disposable = vscode.commands.registerCommand('vsc-profiler.profilerFromTask', async (args) => {
+        console.log(args.length, args.length < 3)
+        if (args.length < 3) {
+            vscode.window.showErrorMessage("ProPeek: Please pass a parameter to the task");
+            return;
+        }
+
+        const path = getPathFromTaskArgs(args);
+
+        new ProfilerViewer(context, path, path);
+    });
+
+    context.subscriptions.push(disposable);
+}
+
+/**
+ * Function that returns the path from a list of arguments
+ * @param args array of strings
+ * @returns single path
+ */
+const getPathFromTaskArgs = (args: Array<string>): string => {
+    // accept only 1 arg, which is the 2nd element in the array
+    const realArg = args[1];
+
+    // transform argument from "${path.prof}" to "path.prof"
+    return realArg.replace(/\${(.*?)}/g, '$1');
 }
 
 // This method is called when your extension is deactivated


### PR DESCRIPTION
Added ability to launch profiler from tasks.json:

**example tasks.json:**
```
{
  "version": "2.0.0",
  "tasks": [
    {
      "label": "Open profiler",
      "type": "process",
      "command": "${command:vsc-profiler.profilerFromTask}",
      "args": ["${file}"],
      "problemMatcher": []
    }
  ],
}
```
This will launch the task for the opened editor file. If you want to use a constant, you can replace the args like this:
`"args": ["${C:\\Path\\To\\File.prof}"],`

**example keybindings.json:**
```
[
  {
    "key": "ctrl+alt+p",
    "command": "workbench.action.tasks.runTask",
    "args": "Open profiler"  // must match the label of the task
  }
]
```