### PR TITLE
update to open listings from directory provided in profiler file

### DIFF
--- a/src/services/parser/presentation/lineSummary.ts
+++ b/src/services/parser/presentation/lineSummary.ts
@@ -9,7 +9,7 @@ export async function calculateLineSummary(rawData: ProfilerRawData, profilerTit
 
   const lineSummaryList = [] as LineSummary[];
 
-  const listingFileFilterList = getListingFileFilterList(rawData.ModuleData);
+  const listingFileFilterList = getListingFileFilterList(rawData.ModuleData, rawData.DescriptionData);
 
   for(const module of rawData.ModuleData) {
     const listingFile = getListingFile(module, listingFileFilterList);

--- a/src/services/parser/presentation/moduleDetails.ts
+++ b/src/services/parser/presentation/moduleDetails.ts
@@ -1,6 +1,7 @@
 import { Constants } from "../../../common/Constants";
 import { ModuleDetails } from "../../../common/PresentationData";
 import { ProfilerRawData } from "../profilerRawData";
+import { DescriptionData } from "../raw/descriptionData";
 import { ModuleData } from "../raw/moduleData";
 import { checkModuleFileExists, getFileAndProcedureName, getWorkspaceConfig } from "./common";
 
@@ -16,7 +17,7 @@ export async function calculateModuleDetails(rawData: ProfilerRawData, totalSess
 
   const moduleDetailsList = [getSessionModuleDetails()] as ModuleDetails[];
 
-  const listingFileFilterList = getListingFileFilterList(rawData.ModuleData);
+  const listingFileFilterList = getListingFileFilterList(rawData.ModuleData, rawData.DescriptionData);
 
   for(const module of rawData.ModuleData) {
     const listingFile = getListingFile(module, listingFileFilterList);
@@ -101,15 +102,19 @@ export const getListingFile = (moduleData: ModuleData, listingFileFilterList: Li
 /**
  * Filters out the listing files and returns the array
  * @param {ModuleData[]} moduleDataList module data list 
+ * @param {DescriptionData[]} descriptionData description data
  * @returns {ListingFileFilter[]} listing file filter array
  */
-export const getListingFileFilterList = (moduleDataList: ModuleData[]): ListingFileFilter[] => {
+export const getListingFileFilterList = (moduleDataList: ModuleData[], descriptionData: DescriptionData): ListingFileFilter[] => {
+  const listingDirectoryRaw = descriptionData.Information?.Directory ?? "";
+  const listingDirectory = listingDirectoryRaw ? (listingDirectoryRaw.endsWith('/') ? listingDirectoryRaw : listingDirectoryRaw + '/') : "";
+  
   return moduleDataList
   .filter((moduleData) => moduleData.ListingFile)
   .map((moduleData) => { 
     return { 
       fileName: getFileAndProcedureName(moduleData.ModuleName).fileName, 
-      listingFile: moduleData.ListingFile 
+      listingFile: listingDirectory ? listingDirectory + moduleData.ListingFile : moduleData.ListingFile
     } as ListingFileFilter;
   });
 };

--- a/src/services/parser/raw/descriptionData.ts
+++ b/src/services/parser/raw/descriptionData.ts
@@ -1,10 +1,22 @@
+import { ParserLogger } from "../ParserLogger";
+
 export interface DescriptionData {
   Version     : number,
   Date        : string,
   Description : string,
   SystemTime  : string,
   UnusedString: string,
-  Information?: string
+  Information?: DescriptionInformation
+}
+
+export interface DescriptionInformation {
+  StmtCnt   : number,
+  DataPts   : number,
+  NumWrites : number,
+  TotalTime : number,
+  BufferSize: number,
+  Directory : string,
+  Propath   : string,
 }
 
 /**
@@ -25,7 +37,15 @@ export function parseDescriptionLine ( line : string ) : DescriptionData {
   };
 
   if (version >= 3) {
-    descriptionData.Information = line.substring(line.indexOf("{")) //could be problematic if description field contains this symbol
+    const informationJson = line.substring(line.indexOf("{")); //could be problematic if description field contains this symbol
+    const escapedJson = informationJson.replace(/\\/g, "\\\\");
+    
+    try {
+      const parsedInformation = JSON.parse(escapedJson);
+      descriptionData.Information = parsedInformation;
+    } catch (error) {
+      ParserLogger.logError("JSON Parsing error", "Unable to parse additional information in profiler description header", error);
+    }
   }
 
   return descriptionData;

--- a/src/view/app/FlameGraph/profilerFlameGraph.tsx
+++ b/src/view/app/FlameGraph/profilerFlameGraph.tsx
@@ -62,7 +62,6 @@ function ProfilerFlameGraph({
 }: IConfigProps) {
   const [searchPhrase, setSearchPhrase] = React.useState<string>("");
   const [selectedSearchType, setSelectedSearchType] = React.useState<SearchTypes>(null);
-  const [graphType, setGraphType] = React.useState<GraphType>(GraphType.Summary);
 
   const [callTree, setCallTree] = React.useState(presentationData.callTree);
   const [windowWidth, setWindowWidth] = React.useState(window.innerWidth);
@@ -183,7 +182,6 @@ function ProfilerFlameGraph({
 
   const handleGraphTypeChange = (event) => {
     const value = event.target.value;
-    setGraphType(value);
     setIsLoading(true);
     showStartTime = value !== GraphType.Summary;
     vscode.postMessage({
@@ -255,7 +253,7 @@ function ProfilerFlameGraph({
           </Box>
           <RadioGroup
             row
-            value={graphType}
+            value={showStartTime ? GraphType.Detailed : GraphType.Summary}
             onChange={handleGraphTypeChange}
           >
             <FormControlLabel


### PR DESCRIPTION
Now prioritzes to open listing files from the profiler header `Directory` json object as per https://github.com/BalticAmadeus/ProPeek/issues/222 .

Otherwise, as previously, tries to find in `**/listing/*` workspace directory.